### PR TITLE
feat: add base_endpoint to FastAPI app for consistent API routing

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ app = FastAPI(
     title="Linked In"
 )
 
-api_bridge = APIBridge(db_config)
+api_bridge = APIBridge(db_config,base_endpoint="/linked-in-apis")
 app.include_router(api_bridge.router)
 
 # Run the app


### PR DESCRIPTION
This commit adds a base_endpoint to the FastAPI application, setting the API routes under /linked-in-apis. This change ensures all API endpoints are prefixed consistently, improving organization and maintainability